### PR TITLE
Active emmet-ls server on js react files

### DIFF
--- a/neovim/.config/nvim/lua/core/lsp/server_settings/emmet_ls.lua
+++ b/neovim/.config/nvim/lua/core/lsp/server_settings/emmet_ls.lua
@@ -1,0 +1,4 @@
+return {
+  filetypes = { "html", "css", "scss", "javascript", "typescript", "typescriptreact", "javascriptreact" }
+}
+


### PR DESCRIPTION
Active [emmet-ls](https://github.com/aca/emmet-ls) for JSX files, default filetypes is HTML and CSS only.

Reference: https://www.reddit.com/r/neovim/comments/ts3pjc/getting_emmetls_to_work_with_scss_and/

---

Prerequists: Install `emmet_ls` servers
```js
:LspInstall emmet_ls
```